### PR TITLE
Update site-values.yaml

### DIFF
--- a/cdpist1vp/tks-cluster/site-values.yaml
+++ b/cdpist1vp/tks-cluster/site-values.yaml
@@ -66,7 +66,7 @@ charts:
           service.beta.kubernetes.io/aws-load-balancer-name: "taco-ingress-nlb"
           service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
           service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
-        type: LoadBalancer
+        type: ClutserIP
       config:
         enable-underscores-in-headers: "true"
         proxy-body-size: "10m"


### PR DESCRIPTION
change service type of ingress-nginx from LoadBalancer to Cluster IP for blocking port scanning via ELB (in case: port 31340)